### PR TITLE
API Update 3.0.0 and 4.0.0

### DIFF
--- a/Changelog.txt
+++ b/Changelog.txt
@@ -16,4 +16,5 @@ v2.0.1#: return true hinzugefügt für onCommand (wegen Console-Error)
 v2.1#: Allgemeines API-Update auf 3.0.0-ALPHA10
 v2.2#: Allgemeines API-Update auf 3.0.0-ALPHA11
 v2.3#: Allgemeines API-Update auf 3.0.0-ALPHA12
+v2.4#: API-Support für 3.0.0 und 4.0.0 hinzugefügt
 v

--- a/plugin.yml
+++ b/plugin.yml
@@ -1,7 +1,7 @@
 name: PixelgamesNoTP
 main: Authors\PixelgamesNoTP\PixelgamesNoTP
-version: 2.3#
-api: [3.0.0-ALPHA12]
+version: 2.4#
+api: [3.0.0-ALPHA12, 3.0.0, 4.0.0]
 load: POSTWORLD
 author: Awzaw, iStrafeNubzHDyt
 website: https://github.com/awzaw

--- a/src/Authors/PixelgamesNoTP/PixelgamesNoTP.php
+++ b/src/Authors/PixelgamesNoTP/PixelgamesNoTP.php
@@ -78,8 +78,8 @@ class PixelgamesNoTP extends PluginBase implements Listener {
                         $issuer->sendMessage("§ePlugin von Awzaw, iStrafeNubzHDyt");
                         $issuer->sendMessage("§bName: PixelgamesNoTP");
                         $issuer->sendMessage("§bOriginal: NoTP");
-                        $issuer->sendMessage("§bVersion: 2.3#");
-                        $issuer->sendMessage("§bFür PocketMine-API: 3.0.0-ALPHA12");
+                        $issuer->sendMessage("§bVersion: 2.4#");
+                        $issuer->sendMessage("§bFür PocketMine-API: 3.0.0-ALPHA12, 3.0.0, 4.0.0");
                         $issuer->sendMessage("§6Permissions: pgnotp, pgnotp.toggle, pgnotp.toggle.self");
                         $issuer->sendMessage("§eSpeziell für PIXELGAMES entwickelt");
                         $issuer->sendMessage("§e-----------------------------");


### PR DESCRIPTION
This makes the plugin compatible with the 3.0.0 and 4.0.0 API versions of PMMP.